### PR TITLE
BluetoothSupport: get_classes: return 0 (unknown) for None device class

### DIFF
--- a/bluewho/bt/support.py
+++ b/bluewho/bt/support.py
@@ -52,8 +52,10 @@ class BluetoothSupport(object):
                 self.classes[major_class][minor_class] = (image_path,
                                                           description)
 
-    def get_classes(self, device_class):
+    def get_classes(self, device_class: int):
         """Return device minor, major class and services class"""
+        if not device_class:
+            return 0, 0, 0
         # Bits 02-07 Minor class bitwise
         minor_class = (device_class & 0xff) >> 2
         # Bits 08-12 Major class bitwise


### PR DESCRIPTION
Fixes #8.

This PR allows unknown / uncategorized devices to appear in the UI (and prevents writing a stacktrace to terminal for every unknown device).

```
Traceback (most recent call last):
  File "/usr/src/bluewho/bluewho/ui/main.py", line 165, in do_add_device
    self.model_devices.add_data(device=device)
  File "/usr/src/bluewho/bluewho/ui/model_devices.py", line 70, in add_data
    minor, major, services_class = self.btsupport.get_classes(
  File "/usr/src/bluewho/bluewho/bt/support.py", line 58, in get_classes
    minor_class = (device_class & 0xff) >> 2
TypeError: unsupported operand type(s) for &: 'NoneType' and 'int'
```

However, this will result in many more detected devices, which may be annoying for users with notifications (+sounds) enabled.

If this PR is merged, it would make sense to also provide an option to hide unknown devices from the UI (hidden by default) or exclude unknown devices from notifications.
